### PR TITLE
Update start.js

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -215,7 +215,7 @@ var statServer = function(options){
 
             app.all(config.context + '/*', function(req, res){
                 proxy.web(req, res, { target: target }, function(err){
-                    res.send(502, err)
+                    res.status(502).send(err)
                 });
             });
         })


### PR DESCRIPTION
express deprecated res.send(status, body): Use res.status(status).send(body) instead
